### PR TITLE
Próximo horário de trabalho

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,2 +1,5 @@
 class DashboardsController < ApplicationController
+  def index
+    @next_entry = Report.next_entry
+  end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,5 @@
 class DashboardsController < ApplicationController
   def index
-    @next_entry = Report.next_entry
+    @next_entry = Report.next_entry(current_user)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,10 +35,10 @@ class Report < ActiveRecord::Base
     last ? last.day : Date.today
   end
 
-  def self.next_entry
-    last_entry = first
+  def self.next_entry(user)
+    last_entry = user.reports.first
     if last_entry.day.cwday < 5
-      last_entry_hour = entry_time(last_entry.first_exit, last_entry.day)
+      last_entry_hour = entry_time(last_entry.second_exit, last_entry.day)
       last_entry_hour + 11.hours
     end
   rescue

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,12 +26,24 @@ class Report < ActiveRecord::Base
     { time: time, sign: sign }
   end
 
+
   def self.find_by_date_range(from, to)
     where('day >= ? AND day <= ?', from, to)
   end
 
   def self.last_day
     last ? last.day : Date.today
+  end
+
+  def self.next_entry
+    last_entry = first
+    if last_entry.day.cwday < 5
+      last_entry_hour = (entry_time(last_entry.second_exit, last_entry.day) ||
+                         entry_time(last_entry.first_exit, last_entry.day))
+      last_entry_hour + 11.hours
+    end
+  rescue
+    nil
   end
 
   private
@@ -83,5 +95,12 @@ class Report < ActiveRecord::Base
 
   def positive_balance?(hours_per_day)
     hours_per_day <= worked
+  end
+
+  def self.entry_time(time, day)
+    if time
+      hour, minute = time.split(':')
+      DateTime.new(day.year, day.month, day.day, hour.to_i, minute.to_i)
+    end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -38,8 +38,7 @@ class Report < ActiveRecord::Base
   def self.next_entry
     last_entry = first
     if last_entry.day.cwday < 5
-      last_entry_hour = (entry_time(last_entry.second_exit, last_entry.day) ||
-                         entry_time(last_entry.first_exit, last_entry.day))
+      last_entry_hour = entry_time(last_entry.first_exit, last_entry.day)
       last_entry_hour + 11.hours
     end
   rescue

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -40,6 +40,25 @@
               Alterar <i class="fa fa-arrow-circle-right"></i>
             <% end %>
         </div>
-    </div>
+      </div>
+      <% if @next_entry %>
+        <div class="col-lg-3 col-xs-6">
+            <!-- small box -->
+            <div class="small-box bg-green">
+                <div class="inner">
+                  <h3>
+                    <%= l @next_entry, format: :only_time %>
+                  </h3>
+                    <p>
+                      Próxima Entrada
+                    </p>
+                </div>
+                <div class="icon">
+                    <i class="fa fa-bell-o"></i>
+                </div>
+                <p class="small-box-footer">No dia <strong><%= l @next_entry.to_date %></strong></p>
+            </div>
+        </div>
+      <% end %>
   </div>
 </section>

--- a/config/locales/pt-BR/rails.yml
+++ b/config/locales/pt-BR/rails.yml
@@ -203,4 +203,5 @@ pt-BR:
       default: ! '%a, %d de %B de %Y, %H:%M:%S %z'
       long: ! '%d de %B de %Y, %H:%M'
       short: ! '%d de %B, %H:%M'
+      only_time: ! '%H:%m'
     pm: ''

--- a/config/locales/pt-BR/rails.yml
+++ b/config/locales/pt-BR/rails.yml
@@ -203,5 +203,5 @@ pt-BR:
       default: ! '%a, %d de %B de %Y, %H:%M:%S %z'
       long: ! '%d de %B de %Y, %H:%M'
       short: ! '%d de %B, %H:%M'
-      only_time: ! '%H:%m'
+      only_time: ! '%H:%M'
     pm: ''

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -75,7 +75,7 @@ describe Report do
     let!(:report) do
       create(:report, day: date, first_exit: first_exit, second_entry: second_entry, second_exit: second_exit)
     end
-    subject { described_class.next_entry }
+    subject { described_class.next_entry(report.user) }
     let(:first_exit) { '12:00' }
     let(:second_entry) { '13:00' }
     let(:second_exit) { '17:00' }
@@ -98,7 +98,7 @@ describe Report do
       let(:second_exit) { nil }
       let(:expected_date) { DateTime.new(2015, 04, 01, 23, 00) }
 
-      it { should eq expected_date }
+      it { should eq nil }
     end
 
     context 'when are missing both exits' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -64,7 +64,7 @@ describe Report do
     end
   end
 
-  describe '#self.find_by_date_range' do
+  describe '.find_by_date_range' do
     let(:date) { Date.new(2014, 02, 03)  }
     it 'find reports by date range' do
       expect(described_class.find_by_date_range(date, date).count).to eq 3


### PR DESCRIPTION
Conforme a lei da CLT, é necessário 11 horas após a última saída para poder realizar a próxima entrada.. O objetivo desta PR, é exibir no dashboard qual o horário da próxima entrada que o funcionário pode bater o ponto.

![next_entry](http://i.imgur.com/Ek15c8D.png)
