### PR TITLE
Horas de trabalho por dia => "HH:MM"

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,7 +20,7 @@ class Report < ActiveRecord::Base
   def balance
     return { time: worked, sign: POSITIVE } unless working_day
 
-    hours_per_day = user.hours_per_day.hour
+    hours_per_day = Time.parse(user.hours_per_day).seconds_since_midnight
     time, sign = away ?  [hours_per_day, NEGATIVE] : [balance_diff(hours_per_day), positive_balance?(hours_per_day)]
 
     { time: time, sign: sign }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ActiveRecord::Base
+  HOURS_IN_GROUPS_OF_FIVE_MINUTES = (Time.now.beginning_of_day.to_i..Time.now.end_of_day.to_i).
+    to_a.in_groups_of(5.minutes).collect(&:first).collect { |t| Time.at(t).strftime("%H:%M") }
+
   has_many :reports
   has_many :timetables
 
@@ -8,7 +11,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :first_name, :last_name, :hours_per_day, presence: true
-  validates :hours_per_day, inclusion: { in: (1..24).map{|h| hour = h < 10 ? "0#{h}" : h; "#{hour}:00"} }
+  validates :hours_per_day, inclusion: { in: HOURS_IN_GROUPS_OF_FIVE_MINUTES }
 
   def total_balance
     nearest_timetable = timetables.first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :first_name, :last_name, :hours_per_day, presence: true
-  validates :hours_per_day, inclusion: { in: 1..24 }
+  validates :hours_per_day, inclusion: { in: (1..24).map{|h| hour = h < 10 ? "0#{h}" : h; "#{hour}:00"} }
 
   def total_balance
     nearest_timetable = timetables.first

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -19,7 +19,8 @@
             <%= f.input :email %>
             <%= f.input :first_name %>
             <%= f.input :last_name %>
-            <%= f.input :hours_per_day %>
+            <%= f.input :hours_per_day, wrapper_html: { class: 'bootstrap-timepicker' },
+                                        input_html: { class: 'timepicker' } %>
             <%= f.input :password %>
             <%= f.input :password_confirmation %>
             <%= f.input :current_password %>

--- a/db/migrate/20150511134855_change_hours_per_day_to_string.rb
+++ b/db/migrate/20150511134855_change_hours_per_day_to_string.rb
@@ -1,0 +1,26 @@
+class ChangeHoursPerDayToString < ActiveRecord::Migration
+  def up
+    change_column :users, :hours_per_day, :string, default: '08:00'
+    new_hours_per_day
+  end
+
+  def down
+    rollback_new_hours_per_day
+    change_column :users, :hours_per_day, :integer, default: 8
+  end
+
+  private
+  def new_hours_per_day
+    User.find_each do |user|
+      new_hours_per_day_hour = user.hours_per_day.to_i < 10 ? "0#{user.hours_per_day}" : user.hours_per_day
+      user.update_attributes(hours_per_day: "#{new_hours_per_day_hour}:00")
+    end
+  end
+
+  def rollback_new_hours_per_day
+    User.find_each do |user|
+      old_hours_per_day_hour = user.hours_per_day.split(':')[0]
+      user.update_attributes(hours_per_day: old_hours_per_day_hour)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141217151955) do
+ActiveRecord::Schema.define(version: 20150511134855) do
 
-  create_table "reports", force: true do |t|
+  create_table "reports", force: :cascade do |t|
     t.string   "first_entry"
     t.string   "first_exit"
     t.string   "second_entry"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20141217151955) do
 
   add_index "reports", ["user_id"], name: "index_reports_on_user_id"
 
-  create_table "timetables", force: true do |t|
+  create_table "timetables", force: :cascade do |t|
     t.date     "closing_day"
     t.integer  "user_id"
     t.datetime "created_at"
@@ -39,13 +39,13 @@ ActiveRecord::Schema.define(version: 20141217151955) do
 
   add_index "timetables", ["user_id"], name: "index_timetables_on_user_id"
 
-  create_table "users", force: true do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  default: "",      null: false
+    t.string   "encrypted_password",     default: "",      null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,       null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20141217151955) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.integer  "hours_per_day",          default: 8
+    t.string   "hours_per_day",          default: "08:00"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,7 @@ describe User do
     end
 
     context 'inclusion' do
-      it { expect(subject).to validate_inclusion_of(:hours_per_day).in_range(1..24) }
+      it { expect(subject).to validate_inclusion_of(:hours_per_day).in_array(User::HOURS_IN_GROUPS_OF_FIVE_MINUTES) }
     end
   end
 


### PR DESCRIPTION
Como mencionado no #31, modifiquei o número de horas de trabalho por dia de `integer` pra ser armazenado como `string` do mesmo jeito dos `reports`.

Logo após a `migration`, dou um update manual pra ficar no padrão `"HH:MM"`

:smile: 