### PR TITLE
Fix layout width

### DIFF
--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -4,7 +4,7 @@
 
 <section class="content">
   <div class="row">
-    <div class="col-md-10">
+    <div class="col-md-12">
       <div class="box box-danger">
         <div class="box-header">
           <h3 class="box-title">Apontamento</h3>


### PR DESCRIPTION
Depois de colocar as 2 colunas pra **Terceira Entrada** e **Terceira Saída**, acabei percebendo que o layout quebrou em uma determinada resolução.

**BEFORE**
<img width="1280" alt="bildschirmfoto 2015-07-08 um 18 04 44" src="https://cloud.githubusercontent.com/assets/356881/8582290/4947d47e-259c-11e5-8f0a-eaed5cf70550.png">

**AFTER**
<img width="1280" alt="bildschirmfoto 2015-07-08 um 18 05 10" src="https://cloud.githubusercontent.com/assets/356881/8582289/49468448-259c-11e5-8870-9be57ec7793c.png">
